### PR TITLE
Add flag for points and area as a type

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -63,8 +63,10 @@ class SiteController < ApplicationController
 
     @chart_greatest_coverage = top_five_countries.reverse.map do |country|
       label = Country.find_by(iso3: country.first).name
+      type = @habitat.name == "coldcorals" ? "points" : "area"
       {
         label: label,
+        type: type,
         value: country.last.round(0),
         percent: 100*country.last/arbitrary_value
       }


### PR DESCRIPTION
This is the initial PR to add a `type` flag which will either be "points" or "area" accordingly.