### PR TITLE
Add change data for mangroves

### DIFF
--- a/app/models/change_stat.rb
+++ b/app/models/change_stat.rb
@@ -1,0 +1,2 @@
+class ChangeStat < ApplicationRecord
+end

--- a/app/models/change_stat.rb
+++ b/app/models/change_stat.rb
@@ -1,2 +1,4 @@
 class ChangeStat < ApplicationRecord
+  belongs_to :habitat, -> { where(name: 'mangroves') }
+  belongs_to :country
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,5 +1,5 @@
 class Country < ApplicationRecord
-  has_many :static_stat
+  has_many :static_stats
   # At the moment, only mangroves have got change stats,
   # which means there can only be one change_stat record per country.
   # This can change in the future

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,2 +1,7 @@
 class Country < ApplicationRecord
+  has_many :static_stat
+  # At the moment, only mangroves have got change stats,
+  # which means there can only be one change_stat record per country.
+  # This can change in the future
+  has_one :change_stat
 end

--- a/app/models/habitat.rb
+++ b/app/models/habitat.rb
@@ -1,5 +1,8 @@
 class Habitat < ApplicationRecord
 
+  has_many :static_stats
+  has_many :change_stats
+
   def global_coverage_title(habitat_type)
     habitat_type == 'points' ? "Total number of #{title.downcase} records globally" : "Total global recorded coverage of #{title.downcase}"
   end

--- a/db/migrate/20191029140219_create_change_stats.rb
+++ b/db/migrate/20191029140219_create_change_stats.rb
@@ -1,0 +1,16 @@
+class CreateChangeStats < ActiveRecord::Migration[5.1]
+  def change
+    create_table :change_stats do |t|
+      t.references :habitat, foreign_key: true
+      t.references :country, foreign_key: true
+      t.decimal :total_value_2007, null: false, default: 0
+      t.decimal :total_value_2008, null: false, default: 0
+      t.decimal :total_value_2009, null: false, default: 0
+      t.decimal :total_value_2010, null: false, default: 0
+      t.decimal :total_value_2015, null: false, default: 0
+      t.integer :baseline_year, null: false, default: 2010
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181120162249) do
+ActiveRecord::Schema.define(version: 20191029140219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "change_stats", force: :cascade do |t|
+    t.bigint "habitat_id"
+    t.bigint "country_id"
+    t.decimal "total_value_2007", default: "0.0", null: false
+    t.decimal "total_value_2008", default: "0.0", null: false
+    t.decimal "total_value_2009", default: "0.0", null: false
+    t.decimal "total_value_2010", default: "0.0", null: false
+    t.decimal "total_value_2015", default: "0.0", null: false
+    t.integer "baseline_year", default: 2010, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_id"], name: "index_change_stats_on_country_id"
+    t.index ["habitat_id"], name: "index_change_stats_on_habitat_id"
+  end
 
   create_table "countries", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +63,8 @@ ActiveRecord::Schema.define(version: 20181120162249) do
     t.index ["habitat_id"], name: "index_static_stats_on_habitat_id"
   end
 
+  add_foreign_key "change_stats", "countries"
+  add_foreign_key "change_stats", "habitats"
   add_foreign_key "static_stats", "countries"
   add_foreign_key "static_stats", "habitats"
 end

--- a/lib/data/countries.csv
+++ b/lib/data/countries.csv
@@ -248,3 +248,4 @@
 "Yemen","YE","YEM",887,"ISO 3166-2:YE","Asia","Western Asia",,142,145,
 "Zambia","ZM","ZMB",894,"ISO 3166-2:ZM","Africa","Sub-Saharan Africa","Eastern Africa",2,202,14
 "Zimbabwe","ZW","ZWE",716,"ISO 3166-2:ZW","Africa","Sub-Saharan Africa","Eastern Africa",2,202,14
+"Disputed","DISP","DISP",,,,,,,,


### PR DESCRIPTION
## Description

* Add change stats table to database. Currently only used for mangroves habitat
* Update `countries.csv` to include a "disputed territories" record (need `rake db:seed`)
* Add relevant associations to models, making sure only mangroves will have change stats data