### PR TITLE
Refresh fix occurrence in regions

### DIFF
--- a/app/models/geo_entity.rb
+++ b/app/models/geo_entity.rb
@@ -32,7 +32,9 @@ class GeoEntity < ApplicationRecord
     hash = {}
 
     _occurrences.map do |occurrence|
-      hash[occurrence['name']] = occurrence['occurrence']
+      _occurrence = occurrence['occurrence']
+      next if hash[occurrence['name']] == 'present'
+      hash[occurrence['name']] = _occurrence unless _occurrence == 'unknown'
     end
     GeoEntityStat::BASE_OCCURRENCES.merge(hash)
   end

--- a/app/serializers/serializers/map_datasets_serializer.rb
+++ b/app/serializers/serializers/map_datasets_serializer.rb
@@ -83,7 +83,9 @@ class Serializers::MapDatasetsSerializer < Serializers::Base
   private
 
   def set_dataset_description_html dataset
-    if habitat_presence_status(dataset) == 'unknown'
+    # TODO Adding nil check is a workaround so to avoid this to break until new data is imported
+    if habitat_presence_status(dataset) == 'unknown' ||
+        @habitat_protection_stats[dataset[:id]].nil?
       dataset[:descriptionHtml] = not_available_dataset_html
     else
       habitat_stats = @habitat_protection_stats[dataset[:id]]
@@ -96,7 +98,7 @@ class Serializers::MapDatasetsSerializer < Serializers::Base
       )
 
       dataset[:descriptionHtml] = I18n.t(
-        'countries.shared.locations_map.filter_description_html', 
+        'countries.shared.locations_map.filter_description_html',
         {
           habitat: dataset[:name],
           habitat_downcase: dataset[:name].downcase,


### PR DESCRIPTION
## Description

This is to fix regional presence not showing correctly.
This also uncovered some issues with the mangroves coverage data for the Mediterranean region.

Regional habitat presence is calculated based on presence within the region's countries; however, the data is not accurate and will be dealt with at a later stage. Some workarounds have been applied so that the app won't break and the mangroves stats on the map are showing as 'not available'

## Notes

Related [codebase ticket](https://unep-wcmc.codebasehq.com/projects/ocean-habitats/tickets/82)