### PR TITLE
ie fix habitat card text width

### DIFF
--- a/app/assets/stylesheets/styles/components/cards/_cards-habitats-present.scss
+++ b/app/assets/stylesheets/styles/components/cards/_cards-habitats-present.scss
@@ -57,6 +57,7 @@
           @include flex-v-center;
           margin-top: rem-calc(22);
           margin-right: auto;
+          width: 100%;
         }
 
           &__habitat-title {


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/ocean-habitats/tickets/165
<img width="205" alt="Screenshot 2021-06-07 at 11 28 51" src="https://user-images.githubusercontent.com/43963744/121001781-8a4edf00-c783-11eb-9a46-414f55452908.png">
Fixes bug in image:


Image is me recreating in chrome as I tested on another laptop so don't have a screenshot on this one!