### PR TITLE
Fix the next country page button

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -43,6 +43,10 @@ class CountriesController < ApplicationController
   private
 
   def next_country
-    GeoEntity.where('name > ?', @country.name).order(:name).first || GeoEntity.first
+    following_countries = GeoEntity.permitted_countries.select { |geo_entity| geo_entity.name > @country.name } 
+    
+    return GeoEntity.permitted_countries.first if following_countries.blank?
+    
+    following_countries.min_by { |geo_entity| geo_entity.name }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,19 +53,7 @@ module ApplicationHelper
   end
 
   def list_of_countries
-    all_countries = GeoEntity.countries.includes(:geo_entity_stats)
-
-    # Using list of allowed countries
-    allowed_countries = ALLOWED_COUNTRIES.map do |iso3|
-      country = GeoEntity.find_by(iso3: iso3)
-      next unless country
-      country
-    end
-
-    # Intersect both arrays to find common countries
-    valid_countries = all_countries.where.not(geo_entity_stats: { id: nil }) & allowed_countries
-
-    valid_countries.sort_by(&:name).map do |country|
+    GeoEntity.permitted_countries.sort_by(&:name).map do |country|
       nav_item(country.actual_name)
     end
   end

--- a/app/models/geo_entity.rb
+++ b/app/models/geo_entity.rb
@@ -17,8 +17,16 @@ class GeoEntity < ApplicationRecord
 
   scope :countries, -> { where.not(iso3: nil || 'GBL') }
   scope :regions, -> { where(iso3: nil) }
+  scope :allowed_countries, -> { countries.includes(:geo_entity_stats).where.not(geo_entity_stats: { id: nil }) }
 
   NEGATIVE_OCCURRENCE_STATUSES = %w[unknown absent present-but-unknown].freeze
+
+  # Only allowing actual countries to be considered for the 'Next country' button
+  def self.permitted_countries
+    permitted = allowed_countries & ALLOWED_COUNTRIES.map { |iso3| find_by(iso3: iso3) }
+
+    permitted.sort_by(&:name)
+  end
 
   # Returns species data if directly attached to the GeoEntity, so a country.
   # Returns species data for all associated countries if it is a region.


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/ocean-habitats/tickets/168

New scope in GeoEntity 
Use the same scope for populating the dropdown list of countries 
Should now wrap around (so Yemen will display a link to Albania) 