### PR TITLE
Move total_value_year fields to new table

### DIFF
--- a/app/models/change_stat.rb
+++ b/app/models/change_stat.rb
@@ -1,5 +1,6 @@
 class ChangeStat < ApplicationRecord
   belongs_to :habitat, -> { where(name: 'mangroves') }
   belongs_to :geo_entity
+  has_many :change_stats_total_values
   validates :habitat_id, uniqueness: { scope: :geo_entity_id }
 end

--- a/app/models/change_stats_total_value.rb
+++ b/app/models/change_stats_total_value.rb
@@ -1,0 +1,3 @@
+class ChangeStatsTotalValue < ApplicationRecord
+	belongs_to :change_stat
+end

--- a/app/models/change_stats_total_value.rb
+++ b/app/models/change_stats_total_value.rb
@@ -1,3 +1,3 @@
 class ChangeStatsTotalValue < ApplicationRecord
-	belongs_to :change_stat
+  belongs_to :change_stat
 end

--- a/db/migrate/20230310154459_create_change_stats_total_values.rb
+++ b/db/migrate/20230310154459_create_change_stats_total_values.rb
@@ -1,0 +1,11 @@
+class CreateChangeStatsTotalValues < ActiveRecord::Migration[5.1]
+  def change
+    create_table :change_stats_total_values do |t|
+      t.integer :change_stat_id
+      t.decimal :total_value, default: 0
+      t.integer :year
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210812135252) do
+ActiveRecord::Schema.define(version: 20230310154459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,14 @@ ActiveRecord::Schema.define(version: 20210812135252) do
     t.datetime "updated_at", null: false
     t.index ["geo_entity_id"], name: "index_change_stats_on_geo_entity_id"
     t.index ["habitat_id"], name: "index_change_stats_on_habitat_id"
+  end
+
+  create_table "change_stats_total_values", force: :cascade do |t|
+    t.integer "change_stat_id"
+    t.decimal "total_value", default: "0.0"
+    t.integer "year"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "coastal_stats", force: :cascade do |t|

--- a/lib/tasks/migrate_change_stats_total_values.rake
+++ b/lib/tasks/migrate_change_stats_total_values.rake
@@ -1,0 +1,17 @@
+namespace :migrate do
+  desc 'Migrate total values from change stats table to new table'
+    task :change_stats_total_values => [:environment] do
+
+    	YEARS = [1996,2007,2008,2009,2010,2015,2016]
+
+        ch = ChangeStat.all
+        ch.each do |c|
+          YEARS.each do |year|
+            total_value = c.send("total_value_#{year}")
+            c.change_stats_total_values.create(total_value: total_value, year: year)
+          end
+        end
+
+        puts "Data migration complete"
+    end
+end


### PR DESCRIPTION
[Ticket#18](https://unep-wcmc.codebasehq.com/projects/ocean-plus/tickets/18)

Created new table _change_stats_total_values_ to move data in total_value_year fields data from change_stats table

run rake db:migrate to create the new table

Run the below rake task to migrate data from _change_stats_ table to the new _change_stats_total_values_ table
rake migrate:change_stats_total_values

This is still in progress:
ToDo

1. Make changes in the code especially in model/habitat.rb to retrieve total_value by year from the new table
2. Update the specs accordingly
3. create a new migration to remove total_value_year fields from _change_stats_ table